### PR TITLE
docker: Build from fedora minimal image instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM registry.gitlab.com/modioab/base-image:fedora-26-python-master
+FROM registry.fedoraproject.org/fedora-minimal
 LABEL maintainer "spider@modio.se"
 
 ENV LANG  C.utf8
 ENV LANGUAGE C.utf8
 ENV LC_ALL C.utf8
 
-RUN ["pip3", "install", "caramel-client"]
+RUN microdnf install python3-pip openssl && \
+    microdnf clean all                   && \
+    pip3 install caramel-client          && \
+    rm -rf ~/.cache/pip
 
 VOLUME ["/data"]
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN microdnf install python3-pip openssl && \
 
 VOLUME ["/data"]
 WORKDIR /data
-ENTRYPOINT ["/usr/bin/caramel-client"]
+ENTRYPOINT ["caramel-client"]
 CMD []


### PR DESCRIPTION
This uses a minimal image rather than the modio python3 image.  Final build
gets a bit larger, so more work might be needed.

Issue: ModioAB/caramel-client#1