### PR TITLE
caramelrequest: Make CN the last part

### DIFF
--- a/caramelrequest/certificaterequest.py
+++ b/caramelrequest/certificaterequest.py
@@ -168,7 +168,7 @@ class CertificateRequest(object):
         prefix, original_cn = value.split('/CN=')
         if prefix == '/C=SE/OU=Caramel/L=Linköping/O=Modio AB/ST=Östergötland':
             prefix = '/C=SE/ST=Östergötland/L=Linköping/O=Modio AB/OU=Caramel'
-        return '/CN={cn}/{prefix}'.format(prefix=prefix, cn=self.client_id)
+        return '{prefix}/CN={cn}'.format(prefix=prefix, cn=self.client_id)
 
     def ensure_valid_key_file(self):
         have_key = False


### PR DESCRIPTION
This avoids double / in the names by suffixing our CN after what we get from
openssl.

This is pretty damned ugly, but it's what you get when you don't want to link
to openssl, because we want to be compatible without needing a C compiler.